### PR TITLE
improvements link schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ The Richtext class can be receive a single parameter called `schema`. This param
 
 ### Testing
 
+Before the testing, we advise you to use an **environment virtualization tool**, for example, virtualenv:
+
+```sh
+# use virtualenv to create the environment
+virtualenv -p python3 .
+
+# activate the environment
+source bin/activate
+
+# you can execute the tests!
+
+# to desactivate the environment
+deactivate
+```
+
 We use unittest module for tests. In terminal, execute:
 
 ```sh

--- a/storyblok_richtext/html_schema.py
+++ b/storyblok_richtext/html_schema.py
@@ -34,10 +34,16 @@ def image(node):
 
 
 def link(node):
+    attrs = node.get('attrs')
+    linktype = attrs.get('linktype', 'url')
+
+    if (linktype == 'email'):
+        attrs['href'] = 'mailto:' + attrs.get('href')
+
     return {
         'tag': [{
           'tag': 'a',
-          'attrs': node.get('attrs')
+          'attrs': attrs
         }]
     }
 

--- a/storyblok_richtext/html_schema.py
+++ b/storyblok_richtext/html_schema.py
@@ -36,9 +36,15 @@ def image(node):
 def link(node):
     attrs = node.get('attrs')
     linktype = attrs.get('linktype', 'url')
+    anchor = attrs.get('anchor', None)
 
     if (linktype == 'email'):
         attrs['href'] = 'mailto:' + attrs.get('href')
+    
+    if (anchor):
+        attrs['href'] = attrs.get('href') + '#' + anchor
+        del attrs['anchor']
+
 
     return {
         'tag': [{

--- a/storyblok_richtext/tests/test_renderer.py
+++ b/storyblok_richtext/tests/test_renderer.py
@@ -303,3 +303,25 @@ class TestRichtext(unittest.TestCase):
         expected = '<a href="mailto:email@client.com" target="_blank" linktype="email">an email link</a>'
 
         self.assertEqual(resolver.render(data), expected)
+
+    def test_render_link_tag_with_anchor(self):
+        data = {
+            'type': 'doc',
+            'content': [{
+                'text': 'link text',
+                'type': 'text',
+                'marks': [{
+                    'type': 'link',
+                    'attrs': {
+                        'href': '/link',
+                        'target': '_blank',
+                        'uuid': '300aeadc-c82d-4529-9484-f3f8f09cf9f5',
+                        'anchor': 'anchor-text'
+                    }
+                }]
+            }]
+        }
+
+        expected = '<a href="/link#anchor-text" target="_blank" uuid="300aeadc-c82d-4529-9484-f3f8f09cf9f5">link text</a>'
+
+        self.assertEqual(resolver.render(data), expected)

--- a/storyblok_richtext/tests/test_renderer.py
+++ b/storyblok_richtext/tests/test_renderer.py
@@ -282,3 +282,24 @@ class TestRichtext(unittest.TestCase):
         expected = '<p>some text after <strike>strike text</strike></p>'
 
         self.assertEqual(custom_object.render(data), expected)
+    
+    def test_render_link_tag_email(self):
+        data = {
+            'type': 'doc',
+            'content': [{
+                'text': 'an email link',
+                'type': 'text',
+                'marks': [{
+                    'type': 'link',
+                    'attrs': {
+                        'href': 'email@client.com',
+                        'target': '_blank',
+                        'linktype': 'email'
+                    }
+                }]
+            }]
+        }
+
+        expected = '<a href="mailto:email@client.com" target="_blank" linktype="email">an email link</a>'
+
+        self.assertEqual(resolver.render(data), expected)

--- a/storyblok_richtext/tests/test_renderer.py
+++ b/storyblok_richtext/tests/test_renderer.py
@@ -325,3 +325,109 @@ class TestRichtext(unittest.TestCase):
         expected = '<a href="/link#anchor-text" target="_blank" uuid="300aeadc-c82d-4529-9484-f3f8f09cf9f5">link text</a>'
 
         self.assertEqual(resolver.render(data), expected)
+    
+    def test_complext_structure(self):
+        data = {
+            'type': 'doc',
+            'content': [{
+                'type': 'paragraph',
+                'content': [{
+                        'text': 'Lorem',
+                        'type': 'text',
+                        'marks': [{
+                            'type': 'bold'
+                        }]
+                    }, {
+                        'text': ' ipsum, ',
+                        'type': 'text'
+                    }, {
+                        'text': 'dolor',
+                        'type': 'text',
+                        'marks': [{
+                            'type': 'strike'
+                        }]
+                    }, {
+                        'text': ' sit amet ',
+                        'type': 'text'
+                    }, {
+                        'text': 'consectetur',
+                        'type': 'text',
+                        'marks': [{
+                            'type': 'underline'
+                        }]
+                    }, {
+                        'text': ' adipisicing elit. ',
+                        'type': 'text'
+                    }, {
+                        'text': 'Eos architecto',
+                        'type': 'text',
+                        'marks': [{
+                            'type': 'code'
+                        }]
+                    }, {
+                        'text': ' asperiores temporibus ',
+                        'type': 'text'
+                    }, {
+                        'text': 'suscipit harum ',
+                        'type': 'text',
+                        'marks': [{
+                            'type': 'link',
+                            'attrs': {
+                                'href': '/test/our-service',
+                                'uuid': '931e04b7-f701-4fe4-8ec0-78be0bee8809',
+                                'anchor': 'anchor-text',
+                                'target': '_blank',
+                                'linktype': 'story'
+                            }
+                        }]
+                    }, {
+                        'text': 'ut, fugit, cumque ',
+                        'type': 'text'
+                    }, {
+                        'text': 'molestiae ',
+                        'type': 'text',
+                        'marks': [{
+                            'type': 'link',
+                            'attrs': {
+                                'href': 'asdfsdfasf',
+                                'uuid': None,
+                                'anchor': None,
+                                'target': '_blank',
+                                'linktype': 'url'
+                            }
+                        }]
+                    }, {
+                        'text': 'ratione non adipisci, ',
+                        'type': 'text'
+                    }, {
+                        'text': 'facilis',
+                        'type': 'text',
+                        'marks': [{
+                            'type': 'italic'
+                        }]
+                    }, {
+                        'text': ' inventore optio dolores. Rem, perspiciatis ',
+                        'type': 'text'
+                    }, {
+                        'text': 'deserunt!',
+                        'type': 'text',
+                        'marks': [{
+                            'type': 'link',
+                            'attrs': {
+                                'href': '/home',
+                                'uuid': 'fc6a453f-9aa6-4a00-a22d-49c5878f7983',
+                                'anchor': None,
+                                'target': '_self',
+                                'linktype': 'story'
+                            }
+                        }]
+                    }, {
+                        'text': ' Esse, maiores!',
+                        'type': 'text'
+                    }]
+            }]
+        }
+
+        expected = '<p><b>Lorem</b> ipsum, <strike>dolor</strike> sit amet <u>consectetur</u> adipisicing elit. <code>Eos architecto</code> asperiores temporibus <a href="/test/our-service#anchor-text" uuid="931e04b7-f701-4fe4-8ec0-78be0bee8809" target="_blank" linktype="story">suscipit harum </a>ut, fugit, cumque <a href="asdfsdfasf" target="_blank" linktype="url">molestiae </a>ratione non adipisci, <i>facilis</i> inventore optio dolores. Rem, perspiciatis <a href="/home" uuid="fc6a453f-9aa6-4a00-a22d-49c5878f7983" target="_self" linktype="story">deserunt!</a> Esse, maiores!</p>'
+
+        self.assertEqual(resolver.render(data), expected)


### PR DESCRIPTION
This PR is to sync link type schema in JavaScript library changes into the Python library.

So, it adds the new following changes:
* When `anchor` attribute is passed, add it, in the end of `href` value, with the `#` string
* When the link type is an e-mail, add `mailto:` string before the `href` value